### PR TITLE
Use GitHub cache backend API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+      - name: Determine Go version from go.mod
+        run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
       - name: Setup Golang Environment
         uses: actions/setup-go@v2
         with:
@@ -71,21 +73,12 @@ jobs:
           key: nginx-ns1-gslb-${{ github.run_id }}-${{ github.run_number }}
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
-      - name: Cache Docker layers
-        uses: actions/cache@v2.1.6
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: Build Image
         uses: docker/build-push-action@v2
         with:
           file: build/Dockerfile
           context: '.'
           target: local
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: nginx/nginx-ns1-gslb:${{ github.sha }}


### PR DESCRIPTION
Use the new GHA [cache](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api) removing the need for an additional action
