### PR TITLE
Bump nginx-plus-go-client to v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/nginxinc/nginx-ns1-gslb
 go 1.17
 
 require (
-	github.com/nginxinc/nginx-plus-go-sdk v0.8.0
+	github.com/nginxinc/nginx-plus-go-client v0.9.0
 	gopkg.in/ns1/ns1-go.v2 v2.6.3
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/nginxinc/nginx-plus-go-sdk v0.8.0 h1:c8gi/K3ebHgAUCiCdk+2bhgyZCHmRWLhwburxThBEhk=
-github.com/nginxinc/nginx-plus-go-sdk v0.8.0/go.mod h1:QqHe+Px9tTm7GOQUBDQGDQHA9m/J+J3JjHbxgri5gSw=
+github.com/nginxinc/nginx-plus-go-client v0.9.0 h1:vHmdSaJ7rjXbU0kMFUGwVu9QLLVJbk+lQo+WDLCm8P0=
+github.com/nginxinc/nginx-plus-go-client v0.9.0/go.mod h1:FTxOV1t0yFEP/E5gXlI2QyWTOfMZCGObFKhdfHYxBm8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nginxinc/nginx-ns1-gslb/internal"
 	"github.com/nginxinc/nginx-ns1-gslb/internal/input"
 	"github.com/nginxinc/nginx-ns1-gslb/internal/output"
-	"github.com/nginxinc/nginx-plus-go-sdk/client"
+	"github.com/nginxinc/nginx-plus-go-client/client"
 )
 
 const (

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/nginxinc/nginx-ns1-gslb/internal"
 	"github.com/nginxinc/nginx-ns1-gslb/internal/input"
 	"github.com/nginxinc/nginx-ns1-gslb/internal/output"
-	"github.com/nginxinc/nginx-plus-go-sdk/client"
+	"github.com/nginxinc/nginx-plus-go-client/client"
 )
 
 func TestNewAgentFailureNoNGINXPlus(t *testing.T) {

--- a/internal/input/nginx.go
+++ b/internal/input/nginx.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nginxinc/nginx-plus-go-sdk/client"
-	nginx "github.com/nginxinc/nginx-plus-go-sdk/client"
+	"github.com/nginxinc/nginx-plus-go-client/client"
+	nginx "github.com/nginxinc/nginx-plus-go-client/client"
 )
 
 var httpProtocol = "http://"


### PR DESCRIPTION
Looks like dependabot was having problems resolving the new name for the client