### PR TITLE
Remove minor version for cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build Binary
         run: make nginx-ns1-gslb
       - name: Cache Artifacts
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/nginx-ns1-gslb
           key: nginx-ns1-gslb-${{ github.run_id }}-${{ github.run_number }}
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/nginx-ns1-gslb
           key: nginx-ns1-gslb-${{ github.run_id }}-${{ github.run_number }}


### PR DESCRIPTION
We don't need to pin down the version, we can use the major version and get fewer PRs from dependabot.
