### PR TITLE
Add workflow to enable auto-merge for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,19 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"
       - "ciarams87"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"
   - package-ecosystem: "docker"
     directory: "/build"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,18 @@
+name: Dependabot auto-merge
+on: pull_request_target
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  dependabot:
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.3.0
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{ secrets.NGINX_PAT }}


### PR DESCRIPTION
Adds workflow to automatically enable auto-merge on dependabot PRs. The PRs will be merged only after they meet all the required checks and required approvals.
