### PR TITLE
Make linter happy again

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,6 @@ linters-settings:
 linters:
     enable:
     - asciicheck
-    - deadcode
     - errcheck
     - gocyclo
     - errorlint
@@ -52,13 +51,10 @@ linters:
     - predeclared
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
-    - wastedassign
     disable-all: true
 issues:
   max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifeq (${TARGET},local)
 endif
 
 test:
-	go test ./...
+	go test ./... -race -shuffle=on
 
 lint:
 	docker run --pull always --rm -v $(shell pwd):/nginx-ns1-gslb -w /nginx-ns1-gslb -v $(shell go env GOCACHE):/cache/go -e GOCACHE=/cache/go -e GOLANGCI_LINT_CACHE=/cache/go -v $(shell go env GOPATH)/pkg:/go/pkg golangci/golangci-lint:latest golangci-lint --color always run

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginxinc/nginx-ns1-gslb
 
-go 1.18
+go 1.19
 
 require (
 	github.com/nginxinc/nginx-plus-go-client v0.10.0

--- a/internal/agent/configurator.go
+++ b/internal/agent/configurator.go
@@ -2,7 +2,7 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/nginxinc/nginx-ns1-gslb/internal/input"
 	"github.com/nginxinc/nginx-ns1-gslb/internal/output"
@@ -27,7 +27,7 @@ type Config struct {
 
 // ParseConfig reads the configuration file and return a Config object ready to configure agent and resources
 func ParseConfig(path *string) (*Config, error) {
-	data, err := ioutil.ReadFile(*path)
+	data, err := os.ReadFile(*path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading file at %v: %w", path, err)
 	}

--- a/internal/agent/configurator_test.go
+++ b/internal/agent/configurator_test.go
@@ -111,13 +111,16 @@ func TestValidateServicesCfg(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		err := validateServicesCfg(testCase.cfg)
-		if err == nil && testCase.wantErr {
-			t.Errorf("validateServicesCfg err returned <nil>, but err expected an error for case %v", testCase.msg)
-		}
-		if err != nil && !testCase.wantErr {
-			t.Errorf("validateServicesCfg returned an err: %v for case %v", err, testCase.msg)
-		}
+		t.Run(testCase.msg, func(t *testing.T) {
+			t.Parallel()
+			err := validateServicesCfg(testCase.cfg)
+			if err == nil && testCase.wantErr {
+				t.Errorf("validateServicesCfg err returned <nil>, but err expected an error for case %v", testCase.msg)
+			}
+			if err != nil && !testCase.wantErr {
+				t.Errorf("validateServicesCfg returned an err: %v for case %v", err, testCase.msg)
+			}
+		})
 	}
 }
 
@@ -149,12 +152,15 @@ func TestParseExampleConfigs(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		_, err := ParseConfig(&testCase.path)
-		if err == nil && testCase.wantErr {
-			t.Errorf("ParseConfig err returned <nil>, but err expected an error for case %v", testCase.msg)
-		}
-		if err != nil && !testCase.wantErr {
-			t.Errorf("ParseConfig returned an err: %v for case %v", err, testCase.msg)
-		}
+		t.Run(testCase.msg, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseConfig(&testCase.path)
+			if err == nil && testCase.wantErr {
+				t.Errorf("ParseConfig err returned <nil>, but err expected an error for case %v", testCase.msg)
+			}
+			if err != nil && !testCase.wantErr {
+				t.Errorf("ParseConfig returned an err: %v for case %v", err, testCase.msg)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Proposed changes

- Update Go v1.19
- Fix liner complains (change of Go std libraries)
- Remove not supported liner checks
- Run some tests in parallel

Test run:
```
➜  nginx-ns1-gslb git:(fix-library-dependency) make test
go test ./... -race -shuffle=on
?   	github.com/nginxinc/nginx-ns1-gslb/cmd/agent	[no test files]
?   	github.com/nginxinc/nginx-ns1-gslb/internal	[no test files]
ok  	github.com/nginxinc/nginx-ns1-gslb/internal/agent	0.740s
ok  	github.com/nginxinc/nginx-ns1-gslb/internal/input	0.392s
ok  	github.com/nginxinc/nginx-ns1-gslb/internal/output	0.559s
```

Linter:
```
➜  nginx-ns1-gslb git:(fix-library-dependency) make lint
docker run --pull always --rm -v /Users/j.jarosz/work/nginx-ns1-gslb:/nginx-ns1-gslb -w /nginx-ns1-gslb -v /Users/j.jarosz/Library/Caches/go-build:/cache/go -e GOCACHE=/cache/go -e GOLANGCI_LINT_CACHE=/cache/go -v /Users/j.jarosz/go/pkg:/go/pkg golangci/golangci-lint:latest golangci-lint --color always run
latest: Pulling from golangci/golangci-lint
Digest: sha256:af723bd6fb13b3cf2dc6e39b5fbc9a6bd0ada2c6f92ce3590eeb0ce71d9174d4
Status: Image is up to date for golangci/golangci-lint:latest
```


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ns1-gslb/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
